### PR TITLE
Add `rb_obj_class`

### DIFF
--- a/src/intern.rs
+++ b/src/intern.rs
@@ -13,6 +13,7 @@ extern {
     pub fn rb_const_get(module: VALUE, name: ID) -> VALUE;
 
     pub fn rb_inspect(v: VALUE) -> VALUE;
+    pub fn rb_obj_class(obj: VALUE) -> VALUE;
 
     pub fn rb_define_singleton_method(class: VALUE, name: *const c_char, func: ANYARGS<VALUE>, arity: c_int);
 }
@@ -177,6 +178,18 @@ tests! {
             unsafe { rb_inspect(rb_class_new_instance(0, null(), class)) },
             "__test_inspect__ works!".to_ruby()
         );
+    }
+
+
+    #[test]
+    fn test_obj_class(assert: &mut Assertions) {
+        let class = unsafe { rb_obj_class(rb_cObject) };
+        let module = unsafe { rb_obj_class(rb_mKernel) };
+        let instance = unsafe { rb_obj_class(rb_class_new_instance(0, null(), rb_cObject)) };
+
+        assert.rb_eq(lazy_eval("::Class"), class);
+        assert.rb_eq(lazy_eval("::Module"), module);
+        assert.rb_eq(lazy_eval("::Object"), instance);
     }
 
     #[test]


### PR DESCRIPTION
Is it a macro? NO

Is there a macro version? Sort of.

There is `CLASS_OF`, which calls `rb_class_of` (as of now). It [appears][1] that `rb_obj_class`
is what you want most of the time.

Defined in:

2.3 https://github.com/ruby/ruby/blob/v2_3_7/include/ruby/intern.h#L607
2.4 https://github.com/ruby/ruby/blob/v2_4_4/include/ruby/intern.h#L604
2.5 https://github.com/ruby/ruby/blob/v2_5_1/include/ruby/intern.h#L584
2.6 https://github.com/ruby/ruby/blob/v2_6_0_preview2/include/ruby/intern.h#L584

[1]: 
https://github.com/ruby/ruby/blob/8867f285da534970c98f8fd388ea4d92ca750a67/doc/ChangeLog-2.4.0#L1459-L1463