### PR TITLE
Remove `Data` class

### DIFF
--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -67,7 +67,6 @@ extern {
     pub static rb_cArray: VALUE;
     pub static rb_cBinding: VALUE;
     pub static rb_cClass: VALUE;
-    pub static rb_cData: VALUE;
     pub static rb_cDir: VALUE;
     pub static rb_cEncoding: VALUE;
     pub static rb_cEnumerator: VALUE;
@@ -243,11 +242,6 @@ tests! {
     #[test]
     fn test_c_class(assert: &mut Assertions) {
         assert.rb_eq(lazy_eval("::Class"), unsafe { rb_cClass });
-    }
-
-    #[test]
-    fn test_c_data(assert: &mut Assertions) {
-        assert.rb_eq(lazy_eval("::Data"), unsafe { rb_cData });
     }
 
     #[test]


### PR DESCRIPTION
This class is deprecated in newer Ruby versions and it is unlikely
that anyone is using it.