### PR TITLE
Don't continue running AppVeyor builds if one fails

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,9 @@ environment:
     - RUBY_VERSION: head-x64
       RUST_HOST: x86_64-pc-windows-gnu
 
+matrix:
+  fast_finish: true
+
 install:
   # Ruby
   - ps: |


### PR DESCRIPTION
This is especially important since we can't run them in parallel
and don't seem to be able to delete queued builds either.