### PR TITLE
Don't build testing dependencies by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ authors = [
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+testing = ["cstr-macro", "lazy_static"]
+
 [dependencies]
 libc = "0.2"
-cstr-macro = "0.1"
-"lazy_static" = "1.1"
-
+cstr-macro = { version = "0.1", optional = true }
+"lazy_static" = { version = "1.1", optional = true }

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem 'rake-compiler', '~> 1.0'
 gem 'minitest', '~> 5.11'
 
 group :development do
-  gem 'toml'
+  gem 'toml-rb'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -70,10 +70,10 @@ namespace :build do
 
       cp File.expand_path("lib#{libcruby_sys_name}.so", libcruby_sys_path), File.expand_path("lib#{libcruby_sys_name}.dll", libcruby_sys_path)
 
-      sh "cargo rustc -- --cfg test -L #{libruby_path.inspect} -l #{libruby_name} -L #{libcruby_sys_path.inspect} -l #{libcruby_sys_name}"
+      sh "cargo rustc --features testing -- --cfg test -L #{libruby_path.inspect} -l #{libruby_name} -L #{libcruby_sys_path.inspect} -l #{libcruby_sys_name}"
       cp "target/debug/libcruby_sys.dll", "target/debug/tests.#{Platform::DLEXT}"
     else
-      sh 'cargo rustc -- --cfg test -C link-args="-Wl,-undefined,dynamic_lookup"'
+      sh 'cargo rustc --features testing -- --cfg test -C link-args="-Wl,-undefined,dynamic_lookup"'
       cp "target/debug/liblibcruby_sys.#{Platform::LIBEXT}", "target/debug/tests.#{Platform::DLEXT}"
     end
   end

--- a/docs/generator.rb
+++ b/docs/generator.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'toml'
+require 'toml-rb'
 
 module Docs
   class CDef
@@ -349,7 +349,7 @@ module Docs
     end
 
     def cargo_pkg
-      @cargo_pkg ||= TOML.load_file(File.expand_path('Cargo.toml', @root))['package']
+      @cargo_pkg ||= TomlRB.load_file(File.expand_path('Cargo.toml', @root))['package']
     end
 
     def clone


### PR DESCRIPTION
Ideally, we'd use `dev-dependencies` but I can't figure out the
correct incantation to use in the Rakefile `build:tests` task.