### PR TITLE
Add dummy gem for more isolated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ env:
   global:
     - RUST_BACKTRACE=1
     - RUST_VERSION=stable
+    - INSTALL_LIBCRUBY_SYS=true
 
 before_install:
   # Install Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "libcruby-sys"
 version = "0.1.0"
 authors = [
   "Godfrey Chan <godfreykfc@gmail.com>",
-  "Yehuda Katz <wycats@gmail.com>"
+  "Yehuda Katz <wycats@gmail.com>",
+  "Peter Wagenet <peter.wagenet@gmail.com>"
 ]
 
 [lib]

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'rake', '~> 12.3'
-gem 'rake-compiler', '~> 1.0'
-gem 'minitest', '~> 5.11'
-
-group :development do
-  gem 'toml'
-end
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -81,6 +81,24 @@ end
 
 task :test => ['build:extension', 'build:tests'] do
   sh 'ruby -Ilib -Itest -Itarget/debug test/runner.rb'
+
+  # Installing libcruby-sys ensures that everything compiles correctly on installation
+  if ENV['INSTALL_LIBCRUBY_SYS']
+    sh "gem build libcruby_sys.gemspec"
+    # FIXME: Don't hard code
+    sh "gem install libcruby_sys-0.1.0.gem"
+  end
+
+  Dir.chdir(File.expand_path("test/dummy", __dir__)) do
+    Bundler.with_clean_env do
+      unless ENV['INSTALL_LIBCRUBY_SYS']
+        ENV['LIBCRUBY_SYS_PATH'] = __dir__
+      end
+
+      sh "bundle install"
+      sh "bundle exec rake"
+    end
+  end
 end
 
 task :doc do

--- a/libcruby_sys.gemspec
+++ b/libcruby_sys.gemspec
@@ -1,0 +1,20 @@
+Gem::Specification.new do |s|
+  s.name        = 'libcruby_sys'
+  s.version     = '0.1.0'
+  s.licenses    = ['MIT']
+  s.summary     = "This is an example!"
+  s.description = "Much longer explanation of the example!"
+  s.authors     = ["Godfrey Chan", "Yehuda Katz", "Peter Wagenet"],
+  s.email       = ["gofreykfc@gmail.com", "wycats@gmail.com", "peter.wagenet@gmail.com"]
+  s.homepage    = 'https://github.com/tildeio/libcruby-sys'
+  s.metadata    = { "source_code_uri" => "https://github.com/tildeio/libcruby-sys.git" }
+
+  s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\.|docs|test|spec|src|Cargo)/}) }
+  s.extensions    = ["ext/extconf.rb"]
+  s.require_paths = ["lib"]
+
+  s.add_development_dependency "rake", "~> 12.3"
+  s.add_development_dependency "rake-compiler", "~> 1.0"
+  s.add_development_dependency "minitest", "~> 5.11"
+  s.add_development_dependency "toml"
+end

--- a/test/dummy/Gemfile
+++ b/test/dummy/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec
+
+if (path = ENV['LIBCRUBY_SYS_PATH'])
+  gem 'libcruby_sys', path: path
+end

--- a/test/dummy/Rakefile
+++ b/test/dummy/Rakefile
@@ -1,0 +1,17 @@
+require 'rake/extensiontask'
+require "rake/testtask"
+
+Rake::ExtensionTask.new do |ext|
+  ext.name = "dummy"
+  ext.ext_dir = "ext/dummy"
+  ext.lib_dir = "lib"
+end
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
+end
+
+task :test => :compile
+
+task :default => :test

--- a/test/dummy/dummy.gemspec
+++ b/test/dummy/dummy.gemspec
@@ -1,0 +1,19 @@
+# coding: utf-8
+
+Gem::Specification.new do |spec|
+  spec.name          = "dummy"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Yehuda Katz", "Godfrey Chan"]
+  spec.email         = ["wycats@gmail.com", "godfreykfc@gmail.com"]
+
+  spec.summary       = "A dummy gem that re-export the C variables and functions to Ruby-land."
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.extensions    = ["ext/dummy/extconf.rb"]
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "libcruby_sys"
+  spec.add_development_dependency "minitest", "~> 5.11"
+  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "rake-compiler", "~> 1.0"
+end

--- a/test/dummy/ext/dummy/dummy.c
+++ b/test/dummy/ext/dummy/dummy.c
@@ -1,0 +1,257 @@
+#include <ruby.h>
+#include <ruby/intern.h>
+
+
+// libcruby-sys doesn't have a .h
+// Doing the values like this doesn't work correctly
+VALUE RS_Qtrue;
+VALUE RS_Qfalse;
+VALUE RS_Qnil;
+
+long RS_RSTRING_LEN(VALUE str);
+const char* RS_RSTRING_PTR(VALUE str);
+long RS_RARRAY_LEN(VALUE a);
+
+
+
+#define EXPORT_VALUE(name) (rb_define_const(mDummy, #name, RS_ ## name))
+#define EXPORT_INT(name) (rb_define_const(mDummy, #name, INT2FIX(RS_ ##name)))
+#define EXPORT_FUNC(name, arity) (rb_define_singleton_method(mDummy, #name, TEST_ ## name, arity))
+#define EXPORT_RUBY_FUNC(name, arity) (rb_define_singleton_method(mRuby, #name, TEST_RB_ ## name, arity))
+
+static VALUE TEST_RSTRING_LEN(VALUE _self, VALUE val) {
+  return LONG2NUM(RS_RSTRING_LEN(val));
+}
+
+static VALUE TEST_RB_RSTRING_PTR(VALUE _self, VALUE val) {
+  return SIZET2NUM((uintptr_t)RSTRING_PTR(val));
+}
+
+static VALUE TEST_RSTRING_PTR(VALUE _self, VALUE val) {
+  return SIZET2NUM((uintptr_t)RS_RSTRING_PTR(val));
+}
+
+static VALUE TEST_RARRAY_LEN(VALUE _self, VALUE val) {
+  return LONG2NUM(RS_RARRAY_LEN(val));
+}
+
+// static VALUE TEST_RB_RARRAY_PTR(VALUE _self, VALUE val) {
+//   return SIZET2NUM((uintptr_t)RARRAY_PTR(val));
+// }
+
+// static VALUE TEST_RARRAY_PTR(VALUE _self, VALUE val) {
+//   return SIZET2NUM((uintptr_t)RS_RARRAY_PTR(val));
+// }
+
+// static VALUE TEST_RB_RARRAY_CONST_PTR(VALUE _self, VALUE val) {
+//   return SIZET2NUM((uintptr_t)RARRAY_CONST_PTR(val));
+// }
+
+// static VALUE TEST_RARRAY_CONST_PTR(VALUE _self, VALUE val) {
+//   return SIZET2NUM((uintptr_t)RS_RARRAY_CONST_PTR(val));
+// }
+
+// static VALUE TEST_RHASH_SIZE(VALUE _self, VALUE val) {
+//   return LONG2NUM(RS_RHASH_SIZE(val));
+// }
+
+// static VALUE TEST_RB_TYPE_P(VALUE _self, VALUE val, VALUE type) {
+//   int result = RS_RB_TYPE_P(val, FIX2INT(type));
+//   return result ? Qtrue : Qfalse;
+// }
+
+// static VALUE TEST_RB_NIL_P(VALUE _self, VALUE val) {
+//   int result = RS_RB_NIL_P(val);
+//   return result ? Qtrue : Qfalse;
+// }
+
+// static VALUE TEST_RTEST(VALUE _self, VALUE val) {
+//   int result = RS_RTEST(val);
+//   return result ? Qtrue : Qfalse;
+// }
+
+// static VALUE TEST_OBJ_FROZEN(VALUE _self, VALUE val) {
+//   int result = RS_OBJ_FROZEN(val);
+//   return result ? Qtrue : Qfalse;
+// }
+
+// static VALUE TEST_TYPE(VALUE _self, VALUE val) {
+//   return INT2FIX(RS_TYPE(val));
+// }
+
+// static VALUE TEST_INT2FIX(VALUE _self, VALUE val) {
+//   return RS_INT2FIX(FIX2INT(val));
+// }
+
+// static VALUE TEST_FIX2INT(VALUE _self, VALUE val) {
+//   return INT2FIX(RS_FIX2INT(val));
+// }
+
+// static VALUE TEST_NUM2U64(VALUE _self, VALUE val) {
+//   return ULL2NUM(RS_NUM2U64(val));
+// }
+
+// static VALUE TEST_U642NUM(VALUE _self, VALUE val) {
+//   return RS_U642NUM(NUM2ULL(val));
+// }
+
+// static VALUE TEST_NUM2I64(VALUE _self, VALUE val) {
+//   return LL2NUM(RS_NUM2I64(val));
+// }
+
+// static VALUE TEST_I642NUM(VALUE _self, VALUE val) {
+//   return RS_I642NUM(NUM2LL(val));
+// }
+
+// static VALUE TEST_NUM2U32(VALUE _self, VALUE val) {
+//   return ULL2NUM(RS_NUM2U32(val));
+// }
+
+// static VALUE TEST_U322NUM(VALUE _self, VALUE val) {
+//   return RS_U322NUM(NUM2UINT(val));
+// }
+
+// static VALUE TEST_NUM2I32(VALUE _self, VALUE val) {
+//   return LL2NUM(RS_NUM2I32(val));
+// }
+
+// static VALUE TEST_I322NUM(VALUE _self, VALUE val) {
+//   return RS_I322NUM(NUM2INT(val));
+// }
+
+// static VALUE TEST_NUM2F64(VALUE _self, VALUE val) {
+//   return DBL2NUM(RS_NUM2F64(val));
+// }
+
+// static VALUE TEST_F642NUM(VALUE _self, VALUE val) {
+//   return RS_F642NUM(NUM2DBL(val));
+// }
+
+// static VALUE TEST_STR2STR(VALUE _self, VALUE str, VALUE len) {
+//   return RS_rb_utf8_str_new(RSTRING_PTR(str), FIX2LONG(len));
+// }
+
+// void deallocate_wrapper(void* num) {
+//   free(num);
+// }
+
+// VALUE allocate_wrapper(VALUE klass) {
+//   int* num = malloc(sizeof(int));
+
+//   *num = 0;
+
+//   return RS_Data_Wrap_Struct(klass, NULL, deallocate_wrapper, num);
+// }
+
+// static VALUE TEST_valid_encoding_p(VALUE _self, VALUE str) {
+//   return RS_rb_str_valid_encoding_p(str) ? Qtrue : Qfalse;
+// }
+
+// static VALUE TEST_ascii_only_p(VALUE _self, VALUE str) {
+//   return RS_rb_str_ascii_only_p(str) ? Qtrue : Qfalse;
+// }
+
+// static VALUE TEST_get_data(VALUE _self, VALUE wrapped) {
+//   int* num = RS_Data_Get_Struct_Value(wrapped);
+//   return INT2FIX(*num);
+// }
+
+// static VALUE TEST_get_data_ptr(VALUE _self, VALUE wrapped) {
+//   int* num = RS_Data_Get_Struct_Value(wrapped);
+//   return INT2FIX(num);
+// }
+
+// static VALUE TEST_set_data(VALUE _self, VALUE wrapped, VALUE value) {
+//   int* num = RS_Data_Get_Struct_Value(wrapped);
+//   *num = FIX2INT(value);
+//   return value;
+// }
+
+// static VALUE TEST_replace_data(VALUE _self, VALUE wrapped, VALUE value) {
+//   int* old = RS_Data_Get_Struct_Value(wrapped);
+//   int* new = malloc(sizeof(int));
+
+//   *new = FIX2INT(value);
+
+//   RS_Data_Set_Struct_Value(wrapped, new);
+
+//   free(old);
+
+//   return value;
+// }
+
+void Init_dummy() {
+  VALUE mDummy = rb_define_module("Dummy");
+  VALUE mRuby = rb_define_module_under(mDummy, "Ruby");
+  // VALUE cWrapper = rb_define_class_under(mDummy, "Wrapper", rb_cObject);
+  // rb_define_alloc_func(cWrapper, allocate_wrapper);
+
+  EXPORT_VALUE(Qtrue);
+  EXPORT_VALUE(Qfalse);
+  EXPORT_VALUE(Qnil);
+
+  // EXPORT_INT(T_NONE);
+  // EXPORT_INT(T_NIL);
+  // EXPORT_INT(T_OBJECT);
+  // EXPORT_INT(T_CLASS);
+  // EXPORT_INT(T_ICLASS);
+  // EXPORT_INT(T_MODULE);
+  // EXPORT_INT(T_FLOAT);
+  // EXPORT_INT(T_STRING);
+  // EXPORT_INT(T_REGEXP);
+  // EXPORT_INT(T_ARRAY);
+  // EXPORT_INT(T_HASH);
+  // EXPORT_INT(T_STRUCT);
+  // EXPORT_INT(T_BIGNUM);
+  // EXPORT_INT(T_FILE);
+  // EXPORT_INT(T_FIXNUM);
+  // EXPORT_INT(T_TRUE);
+  // EXPORT_INT(T_FALSE);
+  // EXPORT_INT(T_DATA);
+  // EXPORT_INT(T_MATCH);
+  // EXPORT_INT(T_SYMBOL);
+  // EXPORT_INT(T_RATIONAL);
+  // EXPORT_INT(T_COMPLEX);
+  // EXPORT_INT(T_UNDEF);
+  // EXPORT_INT(T_NODE);
+  // EXPORT_INT(T_ZOMBIE);
+  // EXPORT_INT(T_MASK);
+
+  EXPORT_FUNC(RSTRING_LEN, 1);
+  EXPORT_FUNC(RSTRING_PTR, 1);
+  EXPORT_RUBY_FUNC(RSTRING_PTR, 1);
+  EXPORT_FUNC(RARRAY_LEN, 1);
+  // EXPORT_FUNC(RARRAY_PTR, 1);
+  // EXPORT_RUBY_FUNC(RARRAY_PTR, 1);
+  // EXPORT_FUNC(RARRAY_CONST_PTR, 1);
+  // EXPORT_RUBY_FUNC(RARRAY_CONST_PTR, 1);
+  // EXPORT_FUNC(RHASH_SIZE, 1);
+  // EXPORT_FUNC(RB_TYPE_P, 2);
+  // EXPORT_FUNC(RB_NIL_P, 1);
+  // EXPORT_FUNC(OBJ_FROZEN, 1);
+  // EXPORT_FUNC(TYPE, 1);
+  // EXPORT_FUNC(INT2FIX, 1);
+  // EXPORT_FUNC(FIX2INT, 1);
+  // EXPORT_FUNC(RTEST, 1);
+
+  // EXPORT_FUNC(NUM2U64, 1);
+  // EXPORT_FUNC(U642NUM, 1);
+  // EXPORT_FUNC(NUM2I64, 1);
+  // EXPORT_FUNC(I642NUM, 1);
+  // EXPORT_FUNC(NUM2U32, 1);
+  // EXPORT_FUNC(U322NUM, 1);
+  // EXPORT_FUNC(NUM2I32, 1);
+  // EXPORT_FUNC(I322NUM, 1);
+  // EXPORT_FUNC(NUM2F64, 1);
+  // EXPORT_FUNC(F642NUM, 1);
+
+  // EXPORT_FUNC(STR2STR, 2);
+
+  // EXPORT_FUNC(valid_encoding_p, 1);
+  // EXPORT_FUNC(ascii_only_p, 1);
+
+  // EXPORT_FUNC(get_data, 1);
+  // EXPORT_FUNC(get_data_ptr, 1);
+  // EXPORT_FUNC(set_data, 2);
+  // EXPORT_FUNC(replace_data, 2);
+}

--- a/test/dummy/ext/dummy/extconf.rb
+++ b/test/dummy/ext/dummy/extconf.rb
@@ -4,9 +4,9 @@ root_dir = File.expand_path("../../../../../..", __FILE__)
 
 dir_config "dummy"
 
-if RUBY_PLATFORM =~ /mingw/
-  raise "not implemented"
-  append_ldflags("-L#{root_dir}/windows_build -lhelix-runtime-#{HelixRuntime::VERSION.gsub('.', '-')}")
-end
+# if RUBY_PLATFORM =~ /mingw/
+#   raise "not implemented"
+#   append_ldflags("-L#{root_dir}/windows_build -lhelix-runtime-#{HelixRuntime::VERSION.gsub('.', '-')}")
+# end
 
 create_makefile "dummy"

--- a/test/dummy/ext/dummy/extconf.rb
+++ b/test/dummy/ext/dummy/extconf.rb
@@ -1,0 +1,12 @@
+require "mkmf"
+
+root_dir = File.expand_path("../../../../../..", __FILE__)
+
+dir_config "dummy"
+
+if RUBY_PLATFORM =~ /mingw/
+  raise "not implemented"
+  append_ldflags("-L#{root_dir}/windows_build -lhelix-runtime-#{HelixRuntime::VERSION.gsub('.', '-')}")
+end
+
+create_makefile "dummy"

--- a/test/dummy/test/dummy_test.rb
+++ b/test/dummy/test/dummy_test.rb
@@ -1,0 +1,290 @@
+require 'minitest/autorun'
+
+require 'libcruby-sys'
+
+$LOAD_PATH.unshift File.expand_path('../support/dummy/lib', __FILE__)
+require 'dummy'
+
+
+class DummyTests < Minitest::Test
+
+#   module TYPES
+#     UNTESTED = {}
+
+#     CASES = {
+#       T_NONE:     UNTESTED,
+#       T_NIL:      nil,
+#       T_OBJECT:   Object.new,
+#       T_CLASS:    Class.new,
+#       T_ICLASS:   UNTESTED,
+#       T_MODULE:   Module.new,
+#       T_FLOAT:    1.5,
+#       T_STRING:   "hello",
+#       T_REGEXP:   /hello/,
+#       T_ARRAY:    [],
+#       T_HASH:     {},
+#       T_STRUCT:   Struct.new(:hello).new,
+#       T_BIGNUM:   2 ** 65,
+#       T_FILE:     File.open(__FILE__),
+#       T_FIXNUM:   2,
+#       T_TRUE:     true,
+#       T_FALSE:    false,
+#       T_DATA:     UNTESTED,
+#       T_MATCH:    "hello".match(/hello/),
+#       T_SYMBOL:   :hello,
+#       T_RATIONAL: Rational(1, 2),
+#       T_COMPLEX:  Complex(1, 2),
+#       T_UNDEF:    UNTESTED,
+#       T_NODE:     UNTESTED,
+#       T_ZOMBIE:   UNTESTED,
+#       T_MASK:     UNTESTED
+#     }
+#   end
+
+#   it 'has a version number' do
+#     expect(HelixRuntime::VERSION).not_to be nil
+#   end
+
+  # def test_exports_Qtrue
+  #   assert_equal(true, Dummy::Qtrue)
+  # end
+
+  # def test_exports_Qfalse
+  #   assert_equal(false, Dummy::Qfalse)
+  # end
+
+  # def test_exports_Qnil
+  #   assert_nil(Dummy::Qnil)
+  # end
+
+  def test_RSTRING_LEN_macro
+    assert_equal(5, Dummy.RSTRING_LEN('hello'))
+  end
+
+  def test_RSTRING_PTR_macro
+    refute_equal(Dummy::RSTRING_PTR('hello'), Dummy.RSTRING_PTR('hello'))
+    assert_equal(Dummy.RSTRING_PTR('hello'.freeze), Dummy::RSTRING_PTR('hello'.freeze))
+  end
+
+  def test_RARRAY_LEN_macro
+    assert_equal(5, Dummy.RARRAY_LEN([1,2,3,4,5]))
+  end
+
+#   it 'exports the RARRAY_PTR macro' do
+#     arr = [1,2,3,4,5]
+#     expect(Dummy.RARRAY_PTR([1,2,3,4,5])).to_not eq(Dummy::RARRAY_PTR([1,2,3,4,5]))
+#     expect(Dummy.RARRAY_PTR(arr)).to eq(Dummy::RARRAY_PTR(arr))
+#   end
+
+#   it 'exports the RARRAY_CONST_PTR macro' do
+#     arr = [1,2,3,4,5]
+#     expect(Dummy.RARRAY_CONST_PTR([1,2,3,4,5])).to_not eq(Dummy::RARRAY_CONST_PTR([1,2,3,4,5]))
+#     expect(Dummy.RARRAY_CONST_PTR(arr)).to eq(Dummy::RARRAY_CONST_PTR(arr))
+#   end
+
+#   it 'exports the RHASH_SIZE macro' do
+#     expect(Dummy.RHASH_SIZE({a: 1, b: 2, c: 3, d: 4, e: 5})).to equal(5)
+#   end
+
+#   it 'exports the RB_NIL_P macro' do
+#     expect(Dummy.RB_NIL_P(nil)).to eq(true)
+#     expect(Dummy.RB_NIL_P(:foo)).to eq(false)
+#   end
+
+#   it 'exports the RTEST macro' do
+#     expect(Dummy.RTEST(true)).to eq(true)
+#     expect(Dummy.RTEST(:foo)).to eq(true)
+#     expect(Dummy.RTEST(false)).to eq(false)
+#     expect(Dummy.RTEST(nil)).to eq(false)
+#   end
+
+#   it 'exports the OBJ_FROZEN macro' do
+#     expect(Dummy.OBJ_FROZEN(Object.new)).to eq(false)
+#     expect(Dummy.OBJ_FROZEN(Object.new.freeze)).to eq(true)
+#   end
+
+#   describe 'coercions' do
+#     it "(INT2FIX)" do
+#       expect(Dummy.INT2FIX(10)).to eq(10)
+#     end
+
+#     it "(FIX2INT)" do
+#       expect(Dummy.FIX2INT(10)).to eq(10)
+#     end
+
+#     it "(NUM2U64)" do
+#       expect(Dummy.NUM2U64(10)).to eq(10)
+#     end
+
+#     it "(U642NUM)" do
+#       expect(Dummy.U642NUM(10)).to eq(10)
+#     end
+
+#     it "(NUM2I64)" do
+#       expect(Dummy.NUM2I64(10)).to eq(10)
+#       expect(Dummy.NUM2I64(-10)).to eq(-10)
+#     end
+
+#     it "(I642NUM)" do
+#       expect(Dummy.I642NUM(10)).to eq(10)
+#       expect(Dummy.I642NUM(-10)).to eq(-10)
+#     end
+
+#     it "(NUM2U32)" do
+#       expect(Dummy.NUM2U32(10)).to eq(10)
+#     end
+
+#     it "(U322NUM)" do
+#       expect(Dummy.U322NUM(10)).to eq(10)
+#     end
+
+#     it "(NUM2I32)" do
+#       expect(Dummy.NUM2I32(10)).to eq(10)
+#       expect(Dummy.NUM2I32(-10)).to eq(-10)
+#     end
+
+#     it "(I322NUM)" do
+#       expect(Dummy.I322NUM(10)).to eq(10)
+#       expect(Dummy.I322NUM(-10)).to eq(-10)
+#     end
+
+#     it "(NUM2F64)" do
+#       expect(Dummy.NUM2F64(12.34)).to eq(12.34)
+#       expect(Dummy.NUM2F64(-12.34)).to eq(-12.34)
+#       expect(Dummy.NUM2F64(12)).to eq(12)
+#       expect(Dummy.NUM2F64(-12)).to eq(-12)
+#     end
+
+#     it "(F642NUM)" do
+#       expect(Dummy.F642NUM(12.34)).to eq(12.34)
+#       expect(Dummy.F642NUM(-12.34)).to eq(-12.34)
+#     end
+#   end
+
+#   describe "exports T_* constants:" do
+#     TYPES::CASES.each do |type_name, obj|
+#       next if obj == TYPES::UNTESTED
+#       type = Dummy.const_get(type_name)
+
+#       describe "#{obj.class} is #{type_name}" do
+#         it "(RB_TYPE_P)" do
+#           expect(Dummy.RB_TYPE_P(obj, type)).to be(true)
+#           expect(Dummy.RB_TYPE_P(obj, Dummy::T_NONE)).to be(false)
+#         end
+
+#         it "(TYPE)" do
+#           expect(Dummy.TYPE(obj)).to be(type)
+#         end
+#       end
+#     end
+#   end
+
+#   # it 'exports the RB_TYPE_P macro and T_*' do
+#   #   expect(Dummy.RB_TYPE_P("hello", Dummy::T_STRING)).to be(true)
+#   #   expect(Dummy.RB_TYPE_P({}, Dummy::T_HASH)).to be(true)
+#   #   expect(Dummy.RB_TYPE_P([], Dummy::T_OBJECT)).to be(false)
+#   # end
+
+#   # it 'exports the TYPE macro' do
+#   #   expect(Dummy.TYPE("hello")).to eq(Dummy::T_STRING)
+#   #   expect(Dummy.TYPE({})).to eq(Dummy::T_HASH)
+#   #   expect(Dummy.TYPE([])).to_not eq(Dummy::T_OBJECT)
+#   # end
+
+#   describe "helix_rb_utf8_str_new" do
+#     it "allocates a new string" do
+#       str1 = "hello world"
+#       str2 = Dummy.STR2STR(str1, 5)
+
+#       expect(str2).to eq("hello")
+
+#       str1[0...5] = "goodbye"
+
+#       expect(str1).to eq("goodbye world")
+#       expect(str2).to eq("hello")
+
+#       str2 << " world!"
+
+#       expect(str1).to eq("goodbye world")
+#       expect(str2).to eq("hello world!")
+#     end
+#   end
+
+#   describe "HELIX_rb_str_valid_encoding_p" do
+#     it "matches #valid_encoding?" do
+#       str = "hello world"
+#       expect(Dummy.valid_encoding_p(str)).to eq(str.valid_encoding?)
+
+#       str = "hello world".encode("BIG5")
+#       expect(Dummy.valid_encoding_p(str)).to eq(str.valid_encoding?)
+
+#       str = "hello world".force_encoding("BIG5")
+#       expect(Dummy.valid_encoding_p(str)).to eq(str.valid_encoding?)
+
+#       str = "ｈｅｌｌｏ"
+#       expect(Dummy.valid_encoding_p(str)).to eq(str.valid_encoding?)
+
+#       str = "ｈｅｌｌｏ".encode("BIG5")
+#       expect(Dummy.valid_encoding_p(str)).to eq(str.valid_encoding?)
+
+#       str = "ｈｅｌｌｏ".force_encoding("BIG5")
+#       expect(Dummy.valid_encoding_p(str)).to eq(str.valid_encoding?)
+
+#       str = "\330"
+#       expect(Dummy.valid_encoding_p(str)).to eq(str.valid_encoding?)
+#     end
+#   end
+
+#   describe "HELIX_rb_str_ascii_only_p" do
+#     it "matches #ascii_only?" do
+#       str = "hello world"
+#       expect(Dummy.ascii_only_p(str)).to eq(str.ascii_only?)
+
+#       str = "hello world".encode("BIG5")
+#       expect(Dummy.ascii_only_p(str)).to eq(str.ascii_only?)
+
+#       str = "hello world".force_encoding("BIG5")
+#       expect(Dummy.ascii_only_p(str)).to eq(str.ascii_only?)
+
+#       str = "ｈｅｌｌｏ"
+#       expect(Dummy.ascii_only_p(str)).to eq(str.ascii_only?)
+
+#       str = "ｈｅｌｌｏ".encode("BIG5")
+#       expect(Dummy.ascii_only_p(str)).to eq(str.ascii_only?)
+
+#       str = "ｈｅｌｌｏ".force_encoding("BIG5")
+#       expect(Dummy.ascii_only_p(str)).to eq(str.ascii_only?)
+
+#       str = "\330"
+#       expect(Dummy.ascii_only_p(str)).to eq(str.ascii_only?)
+#     end
+#   end
+
+#   describe "Data_{Wrap,Get,Set}_Struct" do
+#     it "can allocate then change the data" do
+#       wrapper = Dummy::Wrapper.new
+
+#       expect(Dummy.get_data(wrapper)).to eq(0)
+
+#       ptr = Dummy.get_data_ptr(wrapper)
+
+#       expect(Dummy.set_data(wrapper, 1)).to eq(1)
+
+#       expect(Dummy.get_data(wrapper)).to eq(1)
+#       expect(Dummy.get_data_ptr(wrapper)).to eq(ptr)
+#     end
+
+#     it "can allocate then replace the data" do
+#       wrapper = Dummy::Wrapper.new
+
+#       expect(Dummy.get_data(wrapper)).to eq(0)
+
+#       ptr = Dummy.get_data_ptr(wrapper)
+
+#       expect(Dummy.replace_data(wrapper, 1)).to eq(1)
+
+#       expect(Dummy.get_data(wrapper)).to eq(1)
+#       expect(Dummy.get_data_ptr(wrapper)).not_to eq(ptr)
+#     end
+#   end
+end


### PR DESCRIPTION
Built on #59

We're partially limited on testing here by the fact that we don't have a `.h` for libcruby-sys. That said, I don't know how much we actually care, since we don't expect anyone to use this in a pure ruby project. The only point to this dummy app is to make sure that libcruby-sys's built gem actually has what it is supposed to have.