### PR TITLE
Fix the build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,9 @@ authors = [
   "Peter Wagenet <peter.wagenet@gmail.com>"
 ]
 
-[lib]
-crate-type = ["cdylib"]
-
-[features]
-testing = ["cstr-macro", "lazy_static"]
-
 [dependencies]
 libc = "0.2"
-cstr-macro = { version = "0.1", optional = true }
-"lazy_static" = { version = "1.1", optional = true }
+
+[dev-dependencies]
+cstr-macro = "0.1"
+lazy_static = "1.1"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'toml-rb'


### PR DESCRIPTION
There were previously two problems:

1. The `crate-type` was incorrectly "cdylib" even though we really need it to be an "rlib" for consumption.

2. `dev-dependencies` wasn't working since we aren't building with `cargo test`.

This somewhat solves both problems by generating a separate `Cargo.toml`
file for building tests with...

1. The `crate-type` set to "cdylib".
2. The `dev-dependencies` merged into `dependencies`.

This setup should allow existing toolings like RLS to understand our codebase better than before.